### PR TITLE
Adds Scout Clear Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package is **still in development**. It's not ready for use.
 - [x] Based on [Algolia's PHP Client v2](https://github.com/algolia/algoliasearch-client-php/tree/2.0)
 - [x] Contains **macros** from [github.com/algolia/laravel-scout-algolia-macros](https://github.com/algolia/laravel-scout-algolia-macros)
 - [x] **Facade** to provide a "static" interface to access clients, analytics
-- [ ] Consider improve Laravel Scout's `scout:clear` command
+- [x] Adds `scout:clear` command
 - [ ] Introduce **settings management**: Backups and easy synchronization
 - [ ] Manager - **Multiple connections** per project
 - [ ] **Extends Driver's Query Builder** adding more methods: whereIn, whereNotIn, whereNot, whereBetween, and others cases to be studied

--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -71,14 +71,4 @@ final class Algolia
     {
         return $this->container->get('algolia.analytics');
     }
-
-    /**
-     * Get the package version.
-     *
-     * @return string
-     */
-    public function version(): string
-    {
-        return $this->container->get('algolia.version');
-    }
 }

--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Scout Extended.
+ *
+ * (c) Algolia Team <contact@algolia.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Algolia\LaravelScoutExtended\Console;
+
+use Illuminate\Console\Command;
+use Algolia\LaravelScoutExtended\Algolia;
+
+final class ClearCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $signature = 'scout:clear {model}';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = "Clear all of the model's records from the index";
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Algolia $algolia): void
+    {
+        $class = $this->argument('model');
+
+        $algolia->index($class)->clear();
+
+        $this->info('The ['.$class.'] index have been cleared.');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Mockery;
+use Mockery\MockInterface;
+use Algolia\AlgoliaSearch\Index;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\AlgoliaEngine;
+use Algolia\LaravelScoutExtended\Facades\Algolia;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Algolia\AlgoliaSearch\Interfaces\ClientInterface;
 
 class TestCase extends BaseTestCase
 {
@@ -21,5 +28,39 @@ class TestCase extends BaseTestCase
         return [
             'Algolia' => \Algolia\LaravelScoutExtended\Facades\Algolia::class,
         ];
+    }
+
+    protected function mockEngine(): MockInterface
+    {
+        $engineMock = Mockery::mock(AlgoliaEngine::class)->makePartial()->shouldIgnoreMissing();
+
+        $managerMock = Mockery::mock(EngineManager::class)->makePartial()->shouldIgnoreMissing();
+
+        $managerMock->shouldReceive('driver')->andReturn($engineMock);
+
+        $this->swap(EngineManager::class, $managerMock);
+
+        return $engineMock;
+    }
+
+    protected function mockIndex(string $model): MockInterface
+    {
+        $indexMock = Mockery::mock(Index::class);
+
+        $clientMock = Mockery::mock(Algolia::client())->makePartial();
+
+        $clientMock->expects('initIndex')->with((new $model)->searchableAs())->andReturn($indexMock);
+
+        $engineMock = Mockery::mock(AlgoliaEngine::class, [$clientMock])->makePartial();
+
+        $managerMock = Mockery::mock(EngineManager::class)->makePartial();
+
+        $managerMock->shouldReceive('driver')->andReturn($engineMock);
+
+        $this->swap(ClientInterface::class, $clientMock);
+
+        $this->swap(EngineManager::class, $managerMock);
+
+        return $indexMock;
     }
 }

--- a/tests/Unit/AlgoliaTest.php
+++ b/tests/Unit/AlgoliaTest.php
@@ -40,9 +40,4 @@ final class AlgoliaTest extends TestCase
     {
         $this->assertInstanceOf(Analytics::class, $this->algolia->analytics());
     }
-
-    public function testVersionGetter(): void
-    {
-        $this->assertEquals(\Algolia\AlgoliaSearch\Algolia::VERSION, $this->algolia->version());
-    }
 }

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -7,11 +7,6 @@ namespace Tests\Unit;
 use Mockery;
 use Tests\TestCase;
 use Tests\Models\User;
-use Mockery\MockInterface;
-use Algolia\AlgoliaSearch\Index;
-use Laravel\Scout\EngineManager;
-use Laravel\Scout\Engines\AlgoliaEngine;
-use Algolia\LaravelScoutExtended\Facades\Algolia;
 
 final class BuilderTest extends TestCase
 {
@@ -26,14 +21,14 @@ final class BuilderTest extends TestCase
 
     public function testWith(): void
     {
-        $this->mockIndex()->expects('search')->with('foo', Mockery::subset(['aroundRadius' => 1]))->andReturn(['hits' => []]);
+        $this->mockIndex(User::class)->expects('search')->with('foo', Mockery::subset(['aroundRadius' => 1]))->andReturn(['hits' => []]);
 
         User::search('foo')->with(['aroundRadius' => 1])->get();
     }
 
     public function testAroundLatLng(): void
     {
-        $this->mockIndex()->expects('search')->with('bar', Mockery::subset(['aroundLatLng' => '48.8566,2.3522']))->andReturn(['hits' => []]);
+        $this->mockIndex(User::class)->expects('search')->with('bar', Mockery::subset(['aroundLatLng' => '48.8566,2.3522']))->andReturn(['hits' => []]);
 
         User::search('bar')->aroundLatLng(48.8566, 2.3522)->get();
     }
@@ -55,37 +50,5 @@ final class BuilderTest extends TestCase
         $this->assertInstanceOf(User::class, $users->first());
         $this->assertEquals('Foo', $users->first()->name);
         $this->assertEquals('bar@example.com', $users->first()->email);
-    }
-
-    private function mockEngine(): MockInterface
-    {
-        $engineMock = Mockery::mock(AlgoliaEngine::class)->makePartial()->shouldIgnoreMissing();
-
-        $managerMock = Mockery::mock(EngineManager::class)->makePartial()->shouldIgnoreMissing();
-
-        $managerMock->shouldReceive('driver')->andReturn($engineMock);
-
-        $this->swap(EngineManager::class, $managerMock);
-
-        return $engineMock;
-    }
-
-    private function mockIndex(): MockInterface
-    {
-        $indexMock = Mockery::mock(Index::class);
-
-        $clientMock = Mockery::mock(Algolia::client())->makePartial();
-
-        $clientMock->expects('initIndex')->andReturn($indexMock);
-
-        $engineMock = Mockery::mock(AlgoliaEngine::class, [$clientMock])->makePartial();
-
-        $managerMock = Mockery::mock(EngineManager::class)->makePartial();
-
-        $managerMock->shouldReceive('driver')->andReturn($engineMock);
-
-        $this->swap(EngineManager::class, $managerMock);
-
-        return $indexMock;
     }
 }

--- a/tests/Unit/ClearCommandTest.php
+++ b/tests/Unit/ClearCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Tests\Models\User;
+
+final class ClearCommandTest extends TestCase
+{
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testModelIsRequired(): void
+    {
+        $this->artisan('scout:clear')->run();
+    }
+
+    public function testClearsIndex(): void
+    {
+        $this->mockIndex($class = User::class)->expects('clear')->once();
+
+        $this->artisan('scout:clear', ['model' => User::class])->expectsOutput("The [{$class}] index have been cleared.");
+    }
+}


### PR DESCRIPTION
This Pull Request introduces the `scout:clear` command.

**Problem**: Laravel Scout ships with the command `scout:flush`, but that command only delete the records from index that exists on the end-developer's application:
```php
    public function handle(Dispatcher $events)
    {
        $class = $this->argument('model');

        $model = new $class;

        $model::removeAllFromSearch(); // Clears only the records that exists on the database.
        
        $this->info('All ['.$class.'] records have been flushed.');
    }
```

The new command `scout:clear` solves this problem, since the end-user can now entirely clean an  index of a `Model::class`:

```php
    public function handle(Algolia $algolia): void
    {
        $class = $this->argument('model');

        $algolia->index($class)->clear(); // Clears the entire index.

        $this->info('The ['.$class.'] index have been cleared.');
    }
```